### PR TITLE
Install jq library in bootstrap script

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -144,6 +144,14 @@ echo "==> Installing yarn asdf plugin"
 asdf plugin-list | grep yarn || asdf plugin-add yarn
 echo
 
+echo "==> Installing jq (JSON processing cli)…"
+if command -v jq &> /dev/null; then
+  echo "    jq already installed. Skipping."
+else
+  brew install jq
+  echo
+fi
+
 # All done!
 echo "==> SUCCESS! Your development environment is now bootstrapped!"
 echo

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -147,6 +147,7 @@ echo
 echo "==> Installing jq (JSON processing cli)…"
 if command -v jq &> /dev/null; then
   echo "    jq already installed. Skipping."
+  echo
 else
   brew install jq
   echo


### PR DESCRIPTION
@erik-aylward-bl gave me a heads up about this one! When I was running through the `reef` [setup instructions](https://github.com/hellobrightline/reef#setup), the last 1Pass cli command depends on a `jq` library that was not installed on my machine (see: `op item ... | jq ".fields[] | ...`). 

Here I've added installing the `jq` library as part of the workstation bootstrap script (or skipping if already installed). Let me know if that doesn't make sense and I could note this somewhere else!